### PR TITLE
Add an option for pareto optimization

### DIFF
--- a/fitness/trips_samples.go
+++ b/fitness/trips_samples.go
@@ -40,9 +40,9 @@ func (e *TripsAndSamplesEvaluator) Evaluate(sol *isso.Actions) TripsAndSamplesFi
 	}
 }
 
-type TripsAndSamplesComparator struct{}
+type TripsThenSamples struct{}
 
-func (e *TripsAndSamplesComparator) Compare(a, b TripsAndSamplesFitness) int {
+func (e *TripsThenSamples) Compare(a, b TripsAndSamplesFitness) int {
 	if b.Trips == 0 && b.Samples == 0 {
 		return -1
 	}
@@ -53,4 +53,33 @@ func (e *TripsAndSamplesComparator) Compare(a, b TripsAndSamplesFitness) int {
 		return cmp.Compare(a.Samples, b.Samples)
 	}
 	return 1
+}
+
+func (e *TripsThenSamples) IsPareto() bool {
+	return false
+}
+
+type TripsSamplesPareto struct{}
+
+func (e *TripsSamplesPareto) Compare(a, b TripsAndSamplesFitness) int {
+	if b.Trips == 0 && b.Samples == 0 {
+		return -1
+	}
+	if a.Trips == b.Trips {
+		return cmp.Compare(a.Samples, b.Samples)
+	}
+	if a.Samples == b.Samples {
+		return cmp.Compare(a.Trips, b.Trips)
+	}
+	if a.Trips < b.Trips && a.Samples < b.Samples {
+		return -1
+	}
+	if a.Trips > b.Trips && a.Samples > b.Samples {
+		return 1
+	}
+	return 0
+}
+
+func (e *TripsSamplesPareto) IsPareto() bool {
+	return true
 }

--- a/isso_test.go
+++ b/isso_test.go
@@ -116,20 +116,20 @@ func TestParetoProblem(t *testing.T) {
 	}
 
 	capacity := []int{
-		500, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 500,
+		1000, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 1000,
 	}
 
 	requirements := []isso.Requirement{
 		{
 			Subject: "Pest 1",
 			Matrix:  "fruits",
-			Samples: 500,
+			Samples: 1000,
 			Times:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		},
 		{
 			Subject: "Pest 2",
 			Matrix:  "fruits",
-			Samples: 500,
+			Samples: 1000,
 			Times:   []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
 		},
 	}

--- a/isso_test.go
+++ b/isso_test.go
@@ -85,8 +85,7 @@ func TestDefaultProblem(t *testing.T) {
 
 	s := isso.NewSolver(
 		&fitness.TripsAndSamplesEvaluator{},
-		//&fitness.TripsThenSamples{},
-		&fitness.TripsSamplesPareto{},
+		&fitness.TripsThenSamples{},
 	)
 
 	if solution, ok := s.Solve(&p); ok {
@@ -100,6 +99,57 @@ func TestDefaultProblem(t *testing.T) {
 			fmt.Println()
 			fmt.Println("------------------------------------------------------------")
 			fmt.Println()
+		}
+		return
+	}
+	fmt.Println("No solution found")
+}
+
+func TestParetoProblem(t *testing.T) {
+	subjects := []string{
+		"Pest 1",
+		"Pest 2",
+	}
+
+	matrices := []isso.Matrix{
+		{Name: "fruits", CanReuse: []string{}},
+	}
+
+	capacity := []int{
+		500, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 500,
+	}
+
+	requirements := []isso.Requirement{
+		{
+			Subject: "Pest 1",
+			Matrix:  "fruits",
+			Samples: 500,
+			Times:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			Subject: "Pest 2",
+			Matrix:  "fruits",
+			Samples: 500,
+			Times:   []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		},
+	}
+
+	p := isso.NewProblem(
+		subjects,
+		matrices,
+		capacity,
+		requirements,
+	)
+
+	s := isso.NewSolver(
+		&fitness.TripsAndSamplesEvaluator{},
+		&fitness.TripsSamplesPareto{},
+	)
+
+	if solution, ok := s.Solve(&p); ok {
+		fmt.Printf("Found %d solution(s)\n\n", len(solution))
+		for _, sol := range solution {
+			fmt.Printf("(%d trips, %d samples)\n", sol.Fitness.Trips, sol.Fitness.Samples)
 		}
 		return
 	}

--- a/isso_test.go
+++ b/isso_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mlange-42/isso/fitness"
 )
 
-func TestProblem(t *testing.T) {
+func TestDefaultProblem(t *testing.T) {
 	subjects := []string{
 		"Pest 1",
 		"Pest 2",
@@ -85,7 +85,8 @@ func TestProblem(t *testing.T) {
 
 	s := isso.NewSolver(
 		&fitness.TripsAndSamplesEvaluator{},
-		&fitness.TripsAndSamplesComparator{},
+		//&fitness.TripsThenSamples{},
+		&fitness.TripsSamplesPareto{},
 	)
 
 	if solution, ok := s.Solve(&p); ok {


### PR DESCRIPTION
Not sure whether pareto optimitation of both, trips and samples, makes sense for the given problem class.

At least for the default test problem, it finds the same solutions as the "first-trips-then-samples" optimization criterion (see the CI tests).

Can we construct a problem that has multiple pareto-optimal solutions? I.e.:
* ***Can we find a problem where we can save samples by doing more trips?***

=> Yes!

* Two pests, same matrix, each requires 1000 samples
* Pest 1 can be tested Jan-Nov
* Pest 2 can be tested Feb-Dec
* Capacities are `1000 100 100 ... 100 1000`

One end of the pareto optimum is 2 trips: sample all Pest 1 in Jan, all Pest 2 in Dec, saving no samples.
The other end is sampling for both pests every month Feb-Nov, saving 50% of samples.

```
(2 trips, 2000 samples)
(3 trips, 1900 samples)
(4 trips, 1800 samples)
(5 trips, 1700 samples)
(6 trips, 1600 samples)
(7 trips, 1500 samples)
(8 trips, 1400 samples)
(9 trips, 1300 samples)
(10 trips, 1000 samples)
```
